### PR TITLE
Improve text file parsing to eliminate trailing newline characters

### DIFF
--- a/neuston_net.py
+++ b/neuston_net.py
@@ -202,7 +202,7 @@ def do_run(args):
         for keyword in args.filter[1:]:
             if os.path.isfile(keyword):
                 with open(keyword) as f:
-                    filter_keywords.extend(f.readlines())
+                    filter_keywords.extend(f.read().splitlines())
             else:
                 filter_keywords.append(keyword)
 

--- a/neuston_net.py
+++ b/neuston_net.py
@@ -219,7 +219,7 @@ def do_run(args):
                 dd = ifcb.DataDirectory(args.SRC)
         elif os.path.isfile(args.SRC) and args.SRC.endswith('.txt'): # TODO TEST: textfile bin run
             with open(args.SRC,'r') as f:
-                bins = f.readlines()
+                bins = f.read().splitlines()
             parent = os.path.commonpath(bins)
             dd = ifcb.DataDirectory(parent,whitelist=bins)
         else: # single bin # TODO TEST: single bin run
@@ -286,7 +286,7 @@ def do_run(args):
                 img_paths.extend(imgs)
         elif os.path.isfile(args.SRC) and args.SRC.endswith('.txt'): # TODO TEST: textfile img run
             with open(args.SRC,'r') as f:
-                img_paths = f.readlines()
+                img_paths = f.read().splitlines()
                 img_paths = [img.strip() for img in img_paths]
                 img_paths = [img for img in img_paths if img.endswith(IMG_EXTENSIONS)]
         elif args.SRC.endswith(IMG_EXTENSIONS): # single img # TODO TEST: single img run

--- a/neuston_onnx.py
+++ b/neuston_onnx.py
@@ -71,7 +71,7 @@ def do_run(args):
             img_paths.extend(imgs)
     elif os.path.isfile(args.SRC) and args.SRC.endswith(('.txt','.list')):  # TODO TEST: textfile img run
         with open(args.SRC, 'r') as f:
-            img_paths = f.readlines()
+            img_paths = f.read().splitlines()
             img_paths = [img.strip() for img in img_paths]
             img_paths = [img for img in img_paths if img.endswith(IMG_EXTENSIONS)]
     elif args.SRC.endswith(IMG_EXTENSIONS):  # single img # TODO TEST: single img run
@@ -97,7 +97,7 @@ def do_run(args):
     print(classfile)
     if os.path.isfile(classfile):
         with open(classfile) as f:
-            classes = [c.rstrip('\n') for c in f.readlines()]
+            classes = f.read().splitlines()
         output_labels = [classes[idx] for idx in output_classes]
         print(output_labels)
 


### PR DESCRIPTION
These changes fix a bug identified in [this issue](https://github.com/WHOIGit/ifcb_classifier/issues/8) causing newline-delimited filter strings parsed from a text file to retain their newline characters. This prevented these filter strings from successfully matching with filepath patterns, thereby preventing any processing from taking place when using `--filter IN`. 

Specifically, the issue was in the use of `readlines`, which conveniently collects the lines of a text file into a list, but doesn't remove the newline characters. I replaced all calls to `f.readlines()` with `f.read().splitlines()`, which fixed the issue parsing filter strings, and also hopefully eliminated future bugs related parsing some of the other input types that can be passed in as text files.

In [one case](https://github.com/WHOIGit/ifcb_classifier/compare/master...tsgolden:ifcb_classifier:filter-file-parsing?expand=1#diff-0b6d2484034a2f34863b09ee0de944cd3649ac47125e29b62666c78380054385L100-R100) these newline characters were already being stripped off, but I also replaced that occurrence because `splitlines` accounts for all possible newline characters, and so is more universal than the `rstrip('\n')` method used in that case.
