### PR TITLE
Add catch for exceptions coming out of IfcbBinDataset

### DIFF
--- a/neuston_net.py
+++ b/neuston_net.py
@@ -250,7 +250,12 @@ def do_run(args):
                     print('{} result-file(s) already exist - skipping this bin'.format(bin_obj))
                     continue
 
-            bin_dataset = IfcbBinDataset(bin_fileset, classifier.hparams.resize, classifier.hparams.img_norm)
+            try:
+                bin_dataset = IfcbBinDataset(bin_fileset, classifier.hparams.resize, classifier.hparams.img_norm)
+            except Exception as e:
+                error_bins.append((bin_obj, e))
+                continue
+
             image_loader = DataLoader(bin_dataset, batch_size=args.batch_size,
                                       pin_memory=True, num_workers=args.loaders)
 


### PR DESCRIPTION
Hi there! I ended up having issues running this in production against large numbers of bins in cases where `IfcbBinDataset` fails to parse the bin fileset. I'm still not quite sure why exactly it's failing (still need to investigate), but these occasional failures throw uncaught exceptions that cause the whole job to die, rather than just the bad bin. I fixed it for myself by adding a catch, and appending any errors to `error_bins`, a pattern I saw you using elsewhere. This has been running in production for us for several months and I haven't run into any other problems.

Hopefully this fix can be of use to others as well. Let me know if you have any questions or suggestions!